### PR TITLE
feat: add useDebounce hook to optimize filter performance

### DIFF
--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = (value, delay) => {
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+};
+
+export default useDebounce;


### PR DESCRIPTION
Created a reusable useDebounce(value, delay) hook to prevent excessive executions during filtering, improving efficiency.